### PR TITLE
fix(gaussian-packet): add absolute value to wavelength compute

### DIFF
--- a/src/quantum_sim/waves/gaussian_wave_packet.py
+++ b/src/quantum_sim/waves/gaussian_wave_packet.py
@@ -49,7 +49,7 @@ class GaussianWavePacket(WavePacket):
 
         plane_waves = []
         for k, amp in zip(k_values, amplitudes):
-            wavelength = 2 * PI / k if k != 0 else 1e15
+            wavelength = 2 * PI / abs(k) if k != 0 else 1e15
 
             pw = PlaneWave(
                 amplitude=amp,


### PR DESCRIPTION
Renvoie une erreur dans certain cas au calcul de la longueur d'onde : 
<img width="1676" height="461" alt="image" src="https://github.com/user-attachments/assets/9c5e303e-7e94-404b-845a-c990905d627f" />

L'erreur est dû à un piège où la longueur d'onde doit toujours être positive mais où le nombre d'ondes k peut être négatif, donc on doit utiliser sa valeur absolue dans le cas du calcul de la longueur d'onde